### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          julia --project -e 'using Pkg; Pkg.instantiate()'
+          julia --project -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate()'
 
       - name: List installed packages
         run: |


### PR DESCRIPTION
run Pkg.Registry.update() before Pkg.instantiate() to avoid flaky registry issues